### PR TITLE
fix: Fix events update bug

### DIFF
--- a/client/src/components/EventForm.js
+++ b/client/src/components/EventForm.js
@@ -29,6 +29,7 @@ import FormControl from "@material-ui/core/FormControl";
 import FormControlLabel from "@material-ui/core/FormControlLabel";
 import Switch from "@material-ui/core/Switch";
 import Autocomplete from "@material-ui/lab/Autocomplete";
+import { getDbEvents } from "../dbCalls";
 
 const useStyles = makeStyles((theme) => ({
   formControl: {
@@ -62,9 +63,14 @@ const useStyles = makeStyles((theme) => ({
 export default function EventForm(props) {
   const classes = useStyles();
   const { addTeachingMins } = useContext(TeachersContext);
-  const { events, addEvent, editEvent, deleteEvent, deleteEvents } = useContext(
-    EventsContext
-  );
+  const {
+    events,
+    addEvent,
+    editEvent,
+    getEvents,
+    deleteEvent,
+    deleteEvents,
+  } = useContext(EventsContext);
   const { teachers } = useContext(TeachersContext);
   const { students } = useContext(StudentsContext);
   const {
@@ -236,6 +242,7 @@ export default function EventForm(props) {
       });
     }
     addTeachingMins(events, monthStart, monthEnd);
+    // getEvents();
     toggleIsLoading(false);
     hideForm();
   };

--- a/client/src/hooks/useEventsState.js
+++ b/client/src/hooks/useEventsState.js
@@ -14,27 +14,31 @@ export default function (initialEvents) {
   const [events, setEvents] = useState(initialEvents);
   const todaysDate = new Date();
 
+  const getEventsFunc = () => {
+    getDbEvents(todaysDate, setEvents, user);
+  };
+
   return {
     events,
     getEvents: () => {
-      getDbEvents(todaysDate, setEvents, user);
+      getEventsFunc();
     },
     addEvent: async function (event) {
       const newEvents = createNewEvents(event, true);
       addDbEvents(newEvents, user);
-      getDbEvents(todaysDate, setEvents, user);
+      getEventsFunc();
     },
     deleteEvent: async function (event) {
       deleteDbEvent(event, user);
-      getDbEvents(todaysDate, setEvents, user);
+      getEventsFunc();
     },
     deleteEvents: async function (event) {
       deleteDbEvents(event, user);
-      getDbEvents(todaysDate, setEvents, user);
+      getEventsFunc();
     },
     editEvent: async function (editedEvent) {
       editDbEvent(editedEvent, user);
-      getDbEvents(todaysDate, setEvents, user);
+      getEventsFunc();
     },
   };
 }


### PR DESCRIPTION
The events were being updated on the client side before the server could be updated.
- Extract the getEvents function to a separate named function that can be called in
each event hook method